### PR TITLE
Retrieve headers via the cUrl option CURLOPT_HEADERFUNCTION. 

### DIFF
--- a/src/Exception/ProfitErrorException.php
+++ b/src/Exception/ProfitErrorException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PracticalAfas\Exception;
+
+use RuntimeException;
+
+class ProfitErrorException extends RuntimeException
+{
+
+}


### PR DESCRIPTION
In case there is an Profit error headers, return the custom Exception. Using this, you can catch the Profit error and inform the issue to the user.